### PR TITLE
#75 - 리팩토링: 엔티티 연관관계 필드 줄바꿈 변경

### DIFF
--- a/src/main/java/com/junyihong/boardproject/domain/Article.java
+++ b/src/main/java/com/junyihong/boardproject/domain/Article.java
@@ -25,7 +25,10 @@ public class Article extends AuditingFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+    @Setter
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "userId")
+    private UserAccount userAccount; // 유저 정보 (ID)
 
     @Setter @Column(nullable = false) private String title; // 제목
     @Setter @Column(nullable = false, length = 10000) private String content; // 본문

--- a/src/main/java/com/junyihong/boardproject/domain/ArticleComment.java
+++ b/src/main/java/com/junyihong/boardproject/domain/ArticleComment.java
@@ -21,8 +21,14 @@ public class ArticleComment extends AuditingFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(optional = false) private Article article; // 게시글 (ID)
-    @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+    @Setter
+    @ManyToOne(optional = false)
+    private Article article; // 게시글 (ID)
+
+    @Setter
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "userId")
+    private UserAccount userAccount; // 유저 정보 (ID) // 유저 정보 (ID)
 
     @Setter @Column(nullable = false, length = 500) private String content; // 본문
 


### PR DESCRIPTION
여러 줄로 쓰면 코드 줄이 길어져서 한 줄 쓰기를 선택했었는데,
요구사항이 늘어나면서 연관관계가 추가되면
애노테이션이나 코드 패턴이 점점 달라져서
정렬이 보기 좋지 않은 듯

이에 연관관계 필드만 우선 평범한 멀티 라인 스타일로 변경

This closes #75 