### PR TITLE
#67 - Heroku 배포를 위해서 변수명 재작성

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,8 @@ spring:
       client:
         registration:
           kakao:
+            client-id: ${KAKAO_OAUTH2_CLIENT_ID}
+            client-secret: ${KAKAO_OAUTH2_CLIENT_SECRET}
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
             client-authentication-method: POST


### PR DESCRIPTION
배포환경에서 환경변수를 주입하기위한 변수가 없으면 안되서 다시 복구한다.
This fixes #67 